### PR TITLE
Remove "rhui-" prefix from RHEL repository

### DIFF
--- a/tests/integration/targets/setup_docker/tasks/RedHat-7.yml
+++ b/tests/integration/targets/setup_docker/tasks/RedHat-7.yml
@@ -13,8 +13,8 @@
     name: setup_epel
 
 - name: Enable extras repository for RHEL on AWS
-  # RHEL 7.6 uses rhui-REGION-rhel-server-extras and RHEL 7.7+ use rhui-rhel-7-server-rhui-extras-rpms
-  command: yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-rhel-7-server-rhui-extras-rpms
+  # RHEL 7.6 uses REGION-rhel-server-extras and RHEL 7.7+ use rhel-7-server-rhui-extras-rpms
+  command: yum-config-manager --enable REGION-rhel-server-extras rhel-7-server-rhui-extras-rpms
   args:
     warn: no
 


### PR DESCRIPTION
The AMI repositories recently changed and removed the `rhui-` prefix which was causing test failures. That was fixed in ansible-base with https://github.com/ansible/ansible/pull/71130, but a similar fix is needed here.